### PR TITLE
Ignore xcuserdata when generating template

### DIFF
--- a/bin/generate-template
+++ b/bin/generate-template
@@ -8,10 +8,10 @@ to="{{ cookiecutter.project_name }}"
 rm -rf TempProject
 cp -r $from ./TempProject
 
-find TempProject \( -type d -name "Carthage" \) -prune -o -type f -print0 \
-  | xargs -0 ruby -p -i -e "gsub /$from/, \"$to\"" --
+find TempProject \( -type d -name "Carthage" -o -name "xcuserdata" \) -prune -o -type f -print0 \
+  | xargs -0 ruby -p -i -e "gsub /$from/, \"$to\""
 
-find TempProject \( -type d -name "Carthage" \) -prune -o -d -name "$from*" -print0 \
+find TempProject \( -type d -name "Carthage" -o -name "xcuserdata" \) -prune -o -d -name "$from*" -print0 \
   | xargs -0 rename "s/$from([^\/]*)$/$to\$1/"
 
 rm -rf "$to"


### PR DESCRIPTION
Working on TemplateProject.xcodeproj causes an xcuserdata directory to be created, which seems to contain files that aren't UTF-8 and thus cause Ruby's `#gsub` to throw an encoding exception.